### PR TITLE
Added pocket_prover-derive

### DIFF
--- a/pocket_prover-derive/.gitignore
+++ b/pocket_prover-derive/.gitignore
@@ -1,0 +1,4 @@
+
+/target
+**/*.rs.bk
+Cargo.lock

--- a/pocket_prover-derive/Cargo.toml
+++ b/pocket_prover-derive/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pocket_prover-derive"
+version = "0.1.0"
+authors = ["Sven Nilsen <bvssvni@gmail.com>"]
+keywords = ["prover", "solver", "logic", "first-order"]
+description = "Derive procedural macros for `pocket_prover`."
+license = "MIT"
+repository = "https://github.com/advancedresearch/pocket_prover.git"
+homepage = "https://github.com/advancedresearch/pocket_prover"
+documentation = "https://docs.rs/pocket_prover-derive"
+readme = "README.md"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.11.11"
+quote = "0.3.15"
+
+[dev-dependencies]
+pocket_prover = {path = "../"}

--- a/pocket_prover-derive/README.md
+++ b/pocket_prover-derive/README.md
@@ -1,0 +1,34 @@
+# pocket_prover-derive
+
+Derive procedural macros for `pocket_prover`.
+
+Example:
+
+```ignore
+#[macro_use]
+extern crate pocket_prover_derive;
+extern crate pocket_prover;
+
+use pocket_prover::Construct;
+
+#[derive(Construct)]
+pub struct Foo {
+    pub a: u64,
+    pub b: u64,
+}
+```
+
+Since `pocket_prover` uses only `u64`,
+it is the only valid concrete field type.
+
+The macro supports generic arguments, assuming that
+the inner type implements `Construct`:
+
+```ignore
+#[derive(Construct)]
+pub struct Bar<T = ()> {
+    pub foo: T,
+    pub a: u64,
+    pub b: u64,
+}
+```

--- a/pocket_prover-derive/src/lib.rs
+++ b/pocket_prover-derive/src/lib.rs
@@ -1,0 +1,145 @@
+//! # pocket_prover-derive
+//!
+//! Derive procedural macros for `pocket_prover`.
+//!
+//! Example:
+//!
+//! ```ignore
+//! #[macro_use]
+//! extern crate pocket_prover_derive;
+//! extern crate pocket_prover;
+//!
+//! use pocket_prover::Construct;
+//!
+//! #[derive(Construct)]
+//! pub struct Foo {
+//!     pub a: u64,
+//!     pub b: u64,
+//! }
+//! ```
+//!
+//! Since `pocket_prover` uses only `u64`,
+//! it is the only valid concrete field type.
+//!
+//! The macro supports generic arguments, assuming that
+//! the inner type implements `Construct`:
+//!
+//! ```ignore
+//! #[derive(Construct)]
+//! pub struct Bar<T = ()> {
+//!     pub foo: T,
+//!     pub a: u64,
+//!     pub b: u64,
+//! }
+//! ```
+
+extern crate proc_macro;
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use proc_macro::{TokenStream};
+use syn::{
+    Body, Ident, VariantData, PolyTraitRef, Ty, TyParamBound,
+    TraitBoundModifier, WherePredicate, WhereBoundPredicate
+};
+use quote::Tokens;
+
+#[proc_macro_derive(Construct)]
+pub fn construct(input: TokenStream) -> TokenStream {
+    // Construct a string representation of the type definition
+    let s = input.to_string();
+
+    // Parse the string representation
+    let ast = syn::parse_derive_input(&s).unwrap();
+
+    // Build the impl
+    let gen = impl_construct(&ast);
+
+    // Return the generated impl
+    gen.parse().unwrap()
+}
+
+fn impl_construct(ast: &syn::DeriveInput) -> quote::Tokens {
+    if let Body::Struct(ref body) = ast.body {
+        let name = &ast.ident;
+        let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+        // Get field identifier and type for all struct fields.
+        let fields: Vec<(_, Ty)> = if let &VariantData::Struct(ref fields) = body {
+            fields.iter()
+                .map(|field| (
+                    field.ident.as_ref().unwrap(),
+                    field.ty.clone(),
+                )).collect()
+        } else {
+            panic!("Expected struct fields");
+        };
+
+        // Add constraints and compute offsets.
+        let mut where_clause = where_clause.clone();
+        let mut offsets = Tokens::new();
+        let mut i = 0;
+        let mut ns = vec![];
+        for &(_, ref ty) in &fields {
+            let ty_ident = if let &Ty::Path(_, ref parameters) = ty {
+                parameters.segments[0].ident.clone()
+            } else {
+                panic!("Could not find type identifier.")
+            };
+            if ty_ident != &Ident::new("u64") {
+                // Add `T: Construct` constraint.
+                where_clause.predicates.push(WherePredicate::BoundPredicate(WhereBoundPredicate {
+                    bound_lifetimes: vec![],
+                    bounded_ty: ty.clone(),
+                    bounds: vec![TyParamBound::Trait(PolyTraitRef {
+                        bound_lifetimes: vec![],
+                        trait_ref: Ident::new("Construct").into()
+                    }, TraitBoundModifier::None)]
+                }));
+                offsets.append(
+                    format!("let n{} = <{} as Construct>::n();", i, ty_ident)
+                );
+                i += 1;
+            } else {
+                ns.push(i);
+            }
+        }
+
+        // Map arguments to struct fields.
+        let mut field_tokens = Tokens::new();
+        let mut i = 0;
+        for &(ref field, ref ty) in &fields {
+            field_tokens.append(field);
+            field_tokens.append(":");
+            let ty_ident = if let &Ty::Path(_, ref parameters) = ty {
+                parameters.segments[0].ident.clone()
+            } else {
+                panic!("Could not find type identifier.")
+            };
+            if ty_ident == &Ident::new("u64") {
+                field_tokens.append("vs[");
+                if ns[i] != 0 {
+                    field_tokens.append(format!("n{}+", ns[i]-1));
+                }
+                field_tokens.append(&format!("{}", i));
+                field_tokens.append("]");
+                i += 1;
+            } else {
+                field_tokens.append("Construct::construct(vs)");
+            }
+            field_tokens.append(",");
+        }
+
+        quote! {
+            impl #impl_generics Construct for #name #ty_generics #where_clause {
+                fn construct(vs: &[u64]) -> Self {
+                    #offsets
+                    #name {
+                        #field_tokens
+                    }
+                }
+            }
+        }
+    } else {panic!("Must be a struct.")}
+}

--- a/pocket_prover-derive/tests/lib.rs
+++ b/pocket_prover-derive/tests/lib.rs
@@ -1,0 +1,56 @@
+#[macro_use]
+extern crate pocket_prover_derive;
+extern crate pocket_prover;
+
+use pocket_prover::Construct;
+
+#[derive(Construct)]
+pub struct Foo {
+    pub a: u64,
+    pub b: u64,
+}
+
+#[derive(Construct)]
+pub struct Bar<T = ()> {
+    pub foo: T,
+    pub a: u64,
+    pub b: u64,
+}
+
+#[test]
+fn foo_a_b() {
+    let vs = &[1, 2];
+    let foo: Foo = Construct::construct(vs);
+    assert_eq!(foo.a, 1);
+    assert_eq!(foo.b, 2);
+}
+
+#[test]
+fn bar_a_b() {
+    let vs = &[1, 2];
+    let bar: Bar = Construct::construct(vs);
+    assert_eq!(bar.a, 1);
+    assert_eq!(bar.b, 2);
+}
+
+#[test]
+fn bar_foo_a_b() {
+    let vs = &[1, 2, 3, 4];
+    let bar: Bar<Foo> = Construct::construct(vs);
+    assert_eq!(bar.foo.a, 1);
+    assert_eq!(bar.foo.b, 2);
+    assert_eq!(bar.a, 3);
+    assert_eq!(bar.b, 4);
+}
+
+#[test]
+fn bar_bar_foo_a_b() {
+    let vs = &[1, 2, 3, 4, 5, 6];
+    let bar: Bar<Bar<Foo>> = Construct::construct(vs);
+    assert_eq!(bar.foo.foo.a, 1);
+    assert_eq!(bar.foo.foo.b, 2);
+    assert_eq!(bar.foo.a, 3);
+    assert_eq!(bar.foo.b, 4);
+    assert_eq!(bar.a, 5);
+    assert_eq!(bar.b, 6);
+}


### PR DESCRIPTION
Implements procedural macro for deriving the `Construct` trait for a
struct.